### PR TITLE
Avoid Ruby 2.2 warning

### DIFF
--- a/lib/msworddoc/extractor.rb
+++ b/lib/msworddoc/extractor.rb
@@ -308,8 +308,6 @@ module MSWordDoc
       "\x0d" => "\n",         # ASIS: Line Feed
       "\x09" => "\t",         # ASIS: Tab
 
-      "\x0d" => "\n",         # Paragraph ends; \n + U+2029?
-
       "\x0b" => "\n",         # Hard line breaks
 
       "\x2d" => "\x2d",       # ASIS: Breaking hyphens; U+2010?


### PR DESCRIPTION
Under Ruby 2.2:
`msworddoc-extractor-0.1.0/lib/msworddoc/extractor.rb:308: warning: duplicated key at line 311 ignored: "\r"`

The key/value pair `"\x0d" => "\n"` is duplicated in `CHARMAP` – this pull request removes the second occurrence.
