### PR TITLE
Fix Ruby 3.4 frozen string literal warnings

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,50 @@
+name: Test
+
+on: [push]
+
+jobs:
+  test:
+    strategy:
+      fail-fast: false
+      matrix:
+        ruby-version:
+          - '2.0'
+          - '2.1'
+          - '2.2'
+          - '2.3'
+          - '2.4'
+          - '2.5'
+          - '2.6'
+          - '2.7'
+          - '3.0'
+          - '3.1'
+          - '3.2'
+          - '3.3'
+          - '3.4'
+
+    name: Ruby ${{ matrix.ruby-version }}
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Ruby
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: ${{ matrix.ruby-version }}
+    - name: Install dependencies
+      run: bundle install
+    - name: Run tests
+      run: bundle exec rake test
+
+  # A utility job upon which Branch Protection can depend,
+  # thus remaining agnostic of the matrix.
+  test_matrix:
+    if: ${{ always() }}
+    runs-on: ubuntu-latest
+    name: Matrix
+    needs: test
+    steps:
+    - name: Check build matrix status
+      if: ${{ needs.test.result != 'success' }}
+      run: exit 1

--- a/.github/workflows/test_ruby193.yml
+++ b/.github/workflows/test_ruby193.yml
@@ -1,0 +1,38 @@
+name: Test Ruby 1.9
+
+on: [push]
+
+jobs:
+  test:
+    strategy:
+      fail-fast: false
+      matrix:
+        ruby-version:
+          - '1.9'
+
+    name: Ruby ${{ matrix.ruby-version }}
+
+    runs-on: ubuntu-22.04
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Ruby
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: ${{ matrix.ruby-version }}
+    - name: Install dependencies
+      run: bundle install
+    - name: Run tests
+      run: bundle exec rake test
+
+  # A utility job upon which Branch Protection can depend,
+  # thus remaining agnostic of the matrix.
+  test_matrix:
+    if: ${{ always() }}
+    runs-on: ubuntu-latest
+    name: Matrix
+    needs: test
+    steps:
+    - name: Check build matrix status
+      if: ${{ needs.test.result != 'success' }}
+      run: exit 1

--- a/lib/msworddoc/extractor.rb
+++ b/lib/msworddoc/extractor.rb
@@ -236,7 +236,7 @@ module MSWordDoc
       i -= 1
       raise 'could not find suitable heading piece' unless i >= 0
 
-      output = ""
+      output = "".dup
       while length > 0 || length < 0
         pcd = @pcds[i]
 

--- a/msworddoc-extractor.gemspec
+++ b/msworddoc-extractor.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
   gem.version       = '0.2.0'
 
-  has_rake = RUBY_VERSION >= '1.9.'
+  has_rake = RUBY_VERSION >= '1.9.' && RUBY_VERSION < '2.3'
 
   if gem.respond_to? :specification_version then
     gem.specification_version = 3
@@ -39,4 +39,5 @@ Gem::Specification.new do |gem|
     gem.add_dependency 'ruby-ole'
     gem.add_dependency 'rake'  unless has_rake
   end
+  gem.add_development_dependency 'test-unit'
 end


### PR DESCRIPTION
Fix Ruby 3.4 frozen string literal warnings. Without this fix, using this gem with Ruby 3.4 causes warnings like:
```
.../lib/msworddoc/extractor.rb:263: warning: literal string will be frozen in the future (run with --debug-frozen-string-literal for more information)
```

Update gem development dependencies for Ruby >= 2.3.
Add GitHub Actions tests for Ruby 1.9 to Ruby 3.4.